### PR TITLE
Add a set of typical context attributes

### DIFF
--- a/src/discordcr-middleware/context.cr
+++ b/src/discordcr-middleware/context.cr
@@ -5,6 +5,14 @@ module Discord
 
     getter message : Message
 
+    getter state = {} of String => Nil | String | Int32 | Int64 | Float64 | Bool
+
+    property int : Int16 | Int32 | Int64 | Nil
+    property uint : UInt16 | UInt32 | UInt64 | Nil
+    property string : String?
+    property float : Float32 | Float64 | Nil
+    property bool : Bool?
+
     def initialize(@client : Client, @message : Message)
     end
   end


### PR DESCRIPTION
Having these attributes readily available would be helpful and cover some basic use cases so that users don't have to add them themselves via the `add_ctx_property` macros. 

This provides a few narrowly typed `property`, as well as a `state` hash for arbitrarily named properties. Unsure if there's any other that should be added, or if there's any other typical types that should be included in these unions.