### PR TITLE
Re-implement Context

### DIFF
--- a/examples/errors.cr
+++ b/examples/errors.cr
@@ -13,7 +13,7 @@ class ErrorCatcher
     yield
   rescue ex
     channel_id = payload.channel_id
-    context.client.create_message(channel_id, "Sorry, an error occurred: #{ex}")
+    context[Discord::Client].create_message(channel_id, "Sorry, an error occurred: #{ex}")
     raise ex
   end
 end

--- a/examples/errors.cr
+++ b/examples/errors.cr
@@ -6,11 +6,13 @@ require "../src/discordcr-middleware/middleware/prefix"
 # raise an Exception in the trailing block, it is caught by ErrorCatcher
 # middleware, which responds with a heartfelt apology and passes the error up.
 
-class ErrorCatcher < Discord::Middleware
-  def call(context, done)
-    done.call
+class ErrorCatcher
+  include Discord::Middleware
+
+  def call(payload, context)
+    yield
   rescue ex
-    channel_id = context.payload.channel_id
+    channel_id = payload.channel_id
     context.client.create_message(channel_id, "Sorry, an error occurred: #{ex}")
     raise ex
   end

--- a/examples/multiple_events.cr
+++ b/examples/multiple_events.cr
@@ -1,29 +1,31 @@
 require "../discordcr-middleware"
 require "../discordcr-middleware/middleware/prefix"
 
-class TestMiddleware < Discord::Middleware
-  def call(context : Discord::Context(Discord::Message), done)
-    puts "MESSAGE_CREATE from #{context.payload.author.id}"
-    done.call
+class TestMiddleware
+  include Discord::Middleware
+
+  def call(payload : Discord::Message, context : Discord::Context)
+    puts "MESSAGE_CREATE from #{payload.author.id}"
+    yield
   end
 
-  def call(context : Discord::Context(Discord::Gateway::PresenceUpdatePayload), done)
-    puts "PRESENCE_UPDATE from #{context.payload.user.id}"
-    done.call
+  def call(payload : Discord::Gateway::PresenceUpdatePayload, context : Discord::Context)
+    puts "PRESENCE_UPDATE from #{payload.user.id}"
+    yield
   end
 
-  def call(context : Discord::Context(Discord::Gateway::GuildMemberUpdatePayload), done)
-    puts "MEMBER_UPDATE from #{context.payload.user.id}"
+  def call(payload : Discord::Gateway::GuildMemberUpdatePayload, context : Discord::Context, &block)
+    puts "MEMBER_UPDATE from #{payload.user.id}"
   end
 end
 
 client = Discord::Client.new("Bot TOKEN")
 
-client.on_message_create(TestMiddleware.new) do |ctx|
+client.on_message_create(TestMiddleware.new) do |payload, ctx|
   # Do something
 end
 
-client.on_presence_update(TestMiddleware.new) do |ctx|
+client.on_presence_update(TestMiddleware.new) do |payload, ctx|
   # Do something
 end
 

--- a/examples/simple.cr
+++ b/examples/simple.cr
@@ -7,29 +7,35 @@ Discord.add_ctx_property(guild, Discord::Guild?)
 
 # A basic middleware to cache the Channel and Guild from the invoking
 # message. The attached client can be accessed by `context.client`.
-class Common < Discord::Middleware
-  def call(context : Discord::Context(Discord::Message), done)
-    channel = context.channel = context.client.get_channel(context.payload.channel_id)
+class Common
+  include Discord::Middleware
+
+  def call(payload : Discord::Message, context : Discord::Context)
+    channel = context.channel = context.client.get_channel(payload.channel_id)
     if id = channel.guild_id
       context.guild = context.client.get_guild(id)
     end
-    done.call
+    yield
   end
 end
 
 # A basic, customizable prefix check
-class Prefix < Discord::Middleware
+class Prefix
+  include Discord::Middleware
+
   def initialize(@prefix : String)
   end
 
-  def call(context : Discord::Context(Discord::Message), done)
-    done.call if context.payload.content.starts_with?(@prefix)
+  def call(payload : Discord::Message, context : Discord::Context)
+    yield if payload.content.starts_with?(@prefix)
   end
 end
 
 # Responds to the channel with some basic information
-class Test < Discord::Middleware
-  def call(context : Discord::Context(Discord::Message), done)
+class Test
+  include Discord::Middleware
+
+  def call(payload : Discord::Message, context : Discord::Context, &block)
     info = <<-DOC
     Channel: #{context.channel.name}
     Guild: #{context.guild.try &.name}

--- a/examples/trailing_block.cr
+++ b/examples/trailing_block.cr
@@ -1,18 +1,20 @@
 require "../src/discordcr-middleware"
 
-class Prefix < Discord::Middleware
+class Prefix
+  include Discord::Middleware
+
   def initialize(@prefix : String)
   end
 
-  def call(context : Discord::Context(Discord::Message), done)
-    done.call if context.payload.content.starts_with?(@prefix)
+  def call(payload : Discord::Message, context : Discord::Context)
+    yield if payload.content.starts_with?(@prefix)
   end
 end
 
 client = Discord::Client.new("Bot TOKEN")
 
-client.on_message_create(Prefix.new("!ping")) do |context|
-  channel_id = context.payload.channel_id
+client.on_message_create(Prefix.new("!ping")) do |payload|
+  channel_id = payload.channel_id
   client.create_message(channel_id, "pong")
 end
 

--- a/examples/upfront_caching.cr
+++ b/examples/upfront_caching.cr
@@ -1,25 +1,25 @@
 require "../src/discordcr-middleware"
 require "../src/discordcr-middleware/middleware/prefix"
 
-Discord.add_ctx_property! channel, Discord::Channel
-Discord.add_ctx_property guild, Discord::Guild?
-Discord.add_ctx_property member, Discord::GuildMember?
-Discord.add_ctx_property! member_roles, Array(Discord::Role)
-
 class CachedEvent
   include Discord::Middleware
 
+  getter! channel : Discord::Channel
+  getter guild : Discord::Guild?
+  getter member : Discord::GuildMember?
+  getter! member_roles : Array(Discord::Role)
+
   def call(payload : Discord::Message, context : Discord::Context)
-    if cache = context.client.cache
+    if cache = context[Discord::Client].cache
       message = payload
 
-      channel = context.channel = cache.resolve_channel(message.channel_id)
+      @channel = channel = cache.resolve_channel(message.channel_id)
       if id = channel.guild_id
-        guild = context.guild = cache.resolve_guild(id)
-        member = context.member = cache.resolve_member(id, message.author.id)
+        @guild = guild = cache.resolve_guild(id)
+        @member = member = cache.resolve_member(id, message.author.id)
 
         if guild && member
-          context.member_roles = guild.roles.select { |r| member.roles.includes? r.id }
+          @member_roles = guild.roles.select { |r| member.roles.includes? r.id }
         end
       end
 
@@ -38,21 +38,22 @@ client.cache = cache
 
 client.on_message_create(DiscordMiddleware::Prefix.new("!memberinfo"), CachedEvent.new) do |payload, context|
   distinct = "#{payload.author.username}##{payload.author.discriminator}"
-  if member = context.member
+  cached = context[CachedEvent]
+  if member = cached.member
     nick = member.nick
 
     message = <<-DOC
       ```
       User: #{distinct}
       Nickname: #{member.nick.nil? ? "none" : nick}
-      Joined #{context.guild.try &.name}: #{member.joined_at}
-      Roles: #{context.member_roles.map &.name}
+      Joined #{cached.guild.try &.name}: #{member.joined_at}
+      Roles: #{cached.member_roles.map &.name}
       ```
       DOC
 
-    client.create_message(context.channel.id, message)
+    client.create_message(payload.channel_id, message)
   else
-    client.create_message(context.channel.id, "Not in a server..")
+    client.create_message(payload.channel_id, "Not in a server..")
   end
 end
 

--- a/spec/client_spec.cr
+++ b/spec/client_spec.cr
@@ -2,10 +2,11 @@ require "./spec_helper"
 
 module Discord
   describe Client do
+    message_json = %({"attachments": [], "tts": false, "embeds": [], "timestamp": "2017-11-29T14:41:51.808000+00:00", "mention_everyone": false, "id": "385440229341003776", "pinned": false, "edited_timestamp": null, "author": {"username": "z64", "discriminator": "2639", "id": "123", "avatar": "862875f54a2ef6db022512ee0d3b8d20"}, "mention_roles": [], "content": "foo", "channel_id": "326472371441762304", "mentions": [], "type": 0})
+
     context "with multiple event handlers" do
       it "calls stacks and trailing blocks once per event" do
         mw = FlagMiddleware.new
-        message_json = %({"attachments": [], "tts": false, "embeds": [], "timestamp": "2017-11-29T14:41:51.808000+00:00", "mention_everyone": false, "id": "385440229341003776", "pinned": false, "edited_timestamp": null, "author": {"username": "z64", "discriminator": "2639", "id": "123", "avatar": "862875f54a2ef6db022512ee0d3b8d20"}, "mention_roles": [], "content": "foo", "channel_id": "326472371441762304", "mentions": [], "type": 0})
         event = Discord::WebSocket::Packet.new(
           0_i64,
           0_i64,
@@ -20,6 +21,23 @@ module Discord
 
         times_called.should eq 2
       end
+    end
+
+    it "makes each middleware available on context" do
+      mw = FlagMiddleware.new
+      event = Discord::WebSocket::Packet.new(
+        0_i64,
+        0_i64,
+        IO::Memory.new(message_json),
+        "MESSAGE_CREATE")
+
+      channel = ::Channel(Nil).new
+      ::Client.on_message_create(mw) do |payload, context|
+        context[FlagMiddleware].should eq mw
+        channel.send(nil)
+      end
+      ::Client.inject(event)
+      channel.receive
     end
   end
 end

--- a/spec/context_spec.cr
+++ b/spec/context_spec.cr
@@ -1,0 +1,23 @@
+require "./spec_helper"
+
+class Storage
+  getter value
+
+  def initialize(@value : Int32)
+  end
+end
+
+describe Discord::Context do
+  it "stores and recalls values by type" do
+    context = Discord::Context.new
+    context.put Storage.new(1)
+    context[Storage].value.should eq 1
+  end
+
+  it "raises on a type that hasn't been stored" do
+    context = Discord::Context.new
+    expect_raises(Exception) do
+      context[Storage]
+    end
+  end
+end

--- a/spec/middleware/author_spec.cr
+++ b/spec/middleware/author_spec.cr
@@ -17,7 +17,7 @@ describe DiscordMiddleware::Author do
     context "with a matching author" do
       it "calls the next middleware" do
         mw = DiscordMiddleware::Author.new(username: "z64")
-        context = Discord::Context.new(Client)
+        context = Discord::Context.new
 
         mw.call(message, context) { true }.should be_true
       end
@@ -26,7 +26,7 @@ describe DiscordMiddleware::Author do
     context "with a author that doesn't match" do
       it "doesn't call the next middleware" do
         mw = DiscordMiddleware::Author.new(username: "y32")
-        context = Discord::Context.new(Client)
+        context = Discord::Context.new
 
         mw.call(message, context) { true }.should be_falsey
       end

--- a/spec/middleware/author_spec.cr
+++ b/spec/middleware/author_spec.cr
@@ -1,4 +1,6 @@
 require "../spec_helper"
+require "../../src/discordcr-middleware/middleware/attribute"
+require "../../src/discordcr-middleware/middleware/author"
 
 describe DiscordMiddleware::Author do
   describe "#initialize" do
@@ -15,18 +17,18 @@ describe DiscordMiddleware::Author do
     context "with a matching author" do
       it "calls the next middleware" do
         mw = DiscordMiddleware::Author.new(username: "z64")
-        context = Discord::Context(Discord::Message).new(Client, message)
+        context = Discord::Context.new(Client)
 
-        mw.call(context, ->{ true }).should be_true
+        mw.call(message, context) { true }.should be_true
       end
     end
 
     context "with a author that doesn't match" do
       it "doesn't call the next middleware" do
         mw = DiscordMiddleware::Author.new(username: "y32")
-        context = Discord::Context(Discord::Message).new(Client, message)
+        context = Discord::Context.new(Client)
 
-        mw.call(context, ->{ true }).should be_falsey
+        mw.call(message, context) { true }.should be_falsey
       end
     end
   end

--- a/spec/middleware/cached_event_spec.cr
+++ b/spec/middleware/cached_event_spec.cr
@@ -1,4 +1,6 @@
 require "../spec_helper"
+require "../../src/discordcr-middleware/middleware/cached_routes"
+require "../../src/discordcr-middleware/middleware/cached_event"
 
 describe DiscordMiddleware::CachedEvent do
   Cache.cache(guild)
@@ -7,21 +9,18 @@ describe DiscordMiddleware::CachedEvent do
 
   it "always calls the next middleware" do
     mw = DiscordMiddleware::CachedEvent.new
-    context = Discord::Context(Discord::Message).new(Client, message(author_id: 120571255635181568))
-    mw.call(context, ->{ true }).should be_true
+    context = Discord::Context.new(Client)
+    mw.call(message(author_id: 120571255635181568), context) { true }.should be_true
   end
 
   it "caches each property" do
     mw = DiscordMiddleware::CachedEvent.new
-    context = Discord::Context(Discord::Message).new(Client, message(author_id: 120571255635181568))
+    context = Discord::Context.new(Client)
 
-    test = ->do
-      context.channel.should eq channel
-      context.guild.should eq guild
-      context.member.should eq member
-      context.member_roles.map(&.id).should eq member.roles
-    end
-
-    mw.call(context, test)
+    mw.call(message(author_id: 120571255635181568), context) { true }
+    context.channel.should eq channel
+    context.guild.should eq guild
+    context.member.should eq member
+    context.member_roles.map(&.id).should eq member.roles
   end
 end

--- a/spec/middleware/cached_event_spec.cr
+++ b/spec/middleware/cached_event_spec.cr
@@ -9,18 +9,20 @@ describe DiscordMiddleware::CachedEvent do
 
   it "always calls the next middleware" do
     mw = DiscordMiddleware::CachedEvent.new
-    context = Discord::Context.new(Client)
+    context = Discord::Context.new
+    context.put(Client)
     mw.call(message(author_id: 120571255635181568), context) { true }.should be_true
   end
 
   it "caches each property" do
     mw = DiscordMiddleware::CachedEvent.new
-    context = Discord::Context.new(Client)
+    context = Discord::Context.new
+    context.put(Client)
 
     mw.call(message(author_id: 120571255635181568), context) { true }
-    context.channel.should eq channel
-    context.guild.should eq guild
-    context.member.should eq member
-    context.member_roles.map(&.id).should eq member.roles
+    mw.channel.should eq channel
+    mw.guild.should eq guild
+    mw.member.should eq member
+    mw.member_roles.map(&.id).should eq member.roles
   end
 end

--- a/spec/middleware/channel_spec.cr
+++ b/spec/middleware/channel_spec.cr
@@ -1,4 +1,7 @@
 require "../spec_helper"
+require "../../src/discordcr-middleware/middleware/attribute"
+require "../../src/discordcr-middleware/middleware/cached_event"
+require "../../src/discordcr-middleware/middleware/channel"
 
 describe DiscordMiddleware::Channel do
   ch = channel
@@ -36,18 +39,16 @@ describe DiscordMiddleware::Channel do
     context "with a matching channel" do
       it "calls the next middleware" do
         mw = DiscordMiddleware::Channel.new(name: "devs")
-        context = Discord::Context(Discord::Message).new(Client, message)
-
-        mw.call(context, ->{ true }).should be_true
+        context = Discord::Context.new(Client)
+        mw.call(message, context) { true }.should be_true
       end
     end
 
     context "with a channel that doesn't match" do
       it "doesn't call the next middleware" do
         mw = DiscordMiddleware::Channel.new(name: "memes")
-        context = Discord::Context(Discord::Message).new(Client, message)
-
-        mw.call(context, ->{ true }).should be_falsey
+        context = Discord::Context.new(Client)
+        mw.call(message, context) { true }.should be_falsey
       end
     end
   end

--- a/spec/middleware/channel_spec.cr
+++ b/spec/middleware/channel_spec.cr
@@ -39,7 +39,8 @@ describe DiscordMiddleware::Channel do
     context "with a matching channel" do
       it "calls the next middleware" do
         mw = DiscordMiddleware::Channel.new(name: "devs")
-        context = Discord::Context.new(Client)
+        context = Discord::Context.new
+        context.put(Client)
         mw.call(message, context) { true }.should be_true
       end
     end
@@ -47,7 +48,8 @@ describe DiscordMiddleware::Channel do
     context "with a channel that doesn't match" do
       it "doesn't call the next middleware" do
         mw = DiscordMiddleware::Channel.new(name: "memes")
-        context = Discord::Context.new(Client)
+        context = Discord::Context.new
+        context.put(Client)
         mw.call(message, context) { true }.should be_falsey
       end
     end

--- a/spec/middleware/conditional_spec.cr
+++ b/spec/middleware/conditional_spec.cr
@@ -17,7 +17,7 @@ describe DiscordMiddleware::Conditional do
     context "when truthy" do
       it "calls the next middleware" do
         msg = message("!ping")
-        context = Discord::Context.new(Client)
+        context = Discord::Context.new
         mw.call(msg, context) { true }.should be_true
       end
     end
@@ -25,7 +25,7 @@ describe DiscordMiddleware::Conditional do
     context "when falsey" do
       it "doesn't call the next middleware" do
         msg = message("!pong")
-        context = Discord::Context.new(Client)
+        context = Discord::Context.new
         mw.call(msg, context) { true }.should be_falsey
       end
     end

--- a/spec/middleware/conditional_spec.cr
+++ b/spec/middleware/conditional_spec.cr
@@ -1,33 +1,32 @@
 require "../spec_helper"
+require "../../src/discordcr-middleware/middleware/conditional"
 
 describe DiscordMiddleware::Conditional do
   describe "#initialize" do
     it "takes a block that returns a bool" do
-      mw = DiscordMiddleware::Conditional.new ->(ctx : Discord::Context(Discord::Message)) { true }
-      mw.@condition.should be_a Proc(Discord::Context(Discord::Message), Bool)
+      mw = DiscordMiddleware::Conditional.new ->(payload : Discord::Message, ctx : Discord::Context) { true }
+      mw.@condition.should be_a Proc(Discord::Message, Discord::Context, Bool)
     end
   end
 
   describe "#call" do
-    mw = DiscordMiddleware::Conditional.new ->(ctx : Discord::Context(Discord::Message)) do
-      ctx.payload.content == "!ping"
+    mw = DiscordMiddleware::Conditional.new ->(payload : Discord::Message, ctx : Discord::Context) do
+      payload.content == "!ping"
     end
 
     context "when truthy" do
       it "calls the next middleware" do
         msg = message("!ping")
-        context = Discord::Context(Discord::Message).new(Client, msg)
-
-        mw.call(context, ->{ true }).should be_true
+        context = Discord::Context.new(Client)
+        mw.call(msg, context) { true }.should be_true
       end
     end
 
     context "when falsey" do
       it "doesn't call the next middleware" do
         msg = message("!pong")
-        context = Discord::Context(Discord::Message).new(Client, msg)
-
-        mw.call(context, ->{ true }).should be_falsey
+        context = Discord::Context.new(Client)
+        mw.call(msg, context) { true }.should be_falsey
       end
     end
   end

--- a/spec/middleware/error_spec.cr
+++ b/spec/middleware/error_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+require "../../src/discordcr-middleware/middleware/error"
 
 describe DiscordMiddleware::Error do
   describe "#initialize" do
@@ -14,18 +15,18 @@ describe DiscordMiddleware::Error do
   describe "#call" do
     it "calls the next middleware" do
       mw = DiscordMiddleware::Error.new("foo")
-      context = Discord::Context(Discord::Message).new(Client, message)
-
-      mw.call(context, ->{ true }).should be_true
+      context = Discord::Context.new(Client)
+      mw.call(message, context) { true }.should be_true
     end
 
     context "when the next middleware raises" do
       it "forwards the exception" do
         mw = DiscordMiddleware::Error.new { }
-        context = Discord::Context(Discord::Message).new(Client, message)
+        context = Discord::Context.new(Client)
+        msg = message
 
         expect_raises(Exception) do
-          mw.call(context, ->{ raise "exception" })
+          mw.call(msg, context) { raise "exception" }
         end
       end
 
@@ -33,10 +34,10 @@ describe DiscordMiddleware::Error do
         it "calls it" do
           called = false
           mw = DiscordMiddleware::Error.new { called = true }
-          context = Discord::Context(Discord::Message).new(Client, message)
+          context = Discord::Context.new(Client)
 
           begin
-            mw.call(context, ->{ raise "exception" })
+            mw.call(message, context) { raise "exception" }
           rescue
           end
 
@@ -49,10 +50,10 @@ describe DiscordMiddleware::Error do
           called = false
           mw = DiscordMiddleware::Error.new { called = true }
           stack = Discord::Stack.new(mw)
-          context = Discord::Context(Discord::Message).new(Client, message)
+          context = Discord::Context.new(Client)
 
           begin
-            stack.run(context) { raise "exception" }
+            stack.run(message, context) { raise "exception" }
           rescue
           end
 
@@ -66,10 +67,10 @@ describe DiscordMiddleware::Error do
         it "doesn't call it" do
           called = false
           mw = DiscordMiddleware::Error.new { called = true }
-          context = Discord::Context(Discord::Message).new(Client, message)
+          context = Discord::Context.new(Client)
 
           begin
-            mw.call(context, ->{ "OK" })
+            mw.call(message, context) { true }
           rescue
           end
 

--- a/spec/middleware/error_spec.cr
+++ b/spec/middleware/error_spec.cr
@@ -15,14 +15,14 @@ describe DiscordMiddleware::Error do
   describe "#call" do
     it "calls the next middleware" do
       mw = DiscordMiddleware::Error.new("foo")
-      context = Discord::Context.new(Client)
+      context = Discord::Context.new
       mw.call(message, context) { true }.should be_true
     end
 
     context "when the next middleware raises" do
       it "forwards the exception" do
         mw = DiscordMiddleware::Error.new { }
-        context = Discord::Context.new(Client)
+        context = Discord::Context.new
         msg = message
 
         expect_raises(Exception) do
@@ -34,7 +34,7 @@ describe DiscordMiddleware::Error do
         it "calls it" do
           called = false
           mw = DiscordMiddleware::Error.new { called = true }
-          context = Discord::Context.new(Client)
+          context = Discord::Context.new
 
           begin
             mw.call(message, context) { raise "exception" }
@@ -50,7 +50,7 @@ describe DiscordMiddleware::Error do
           called = false
           mw = DiscordMiddleware::Error.new { called = true }
           stack = Discord::Stack.new(mw)
-          context = Discord::Context.new(Client)
+          context = Discord::Context.new
 
           begin
             stack.run(message, context) { raise "exception" }
@@ -67,7 +67,7 @@ describe DiscordMiddleware::Error do
         it "doesn't call it" do
           called = false
           mw = DiscordMiddleware::Error.new { called = true }
-          context = Discord::Context.new(Client)
+          context = Discord::Context.new
 
           begin
             mw.call(message, context) { true }

--- a/spec/middleware/permissions_spec.cr
+++ b/spec/middleware/permissions_spec.cr
@@ -1,4 +1,6 @@
 require "../spec_helper"
+require "../../src/discordcr-middleware/middleware/cached_routes"
+require "../../src/discordcr-middleware/middleware/permissions"
 
 describe DiscordMiddleware::Permissions do
   describe "#base_permissions_for" do
@@ -52,8 +54,8 @@ describe DiscordMiddleware::Permissions do
         perms = Discord::Permissions.flags(ReadMessages, CreateInstantInvite)
         mw = DiscordMiddleware::Permissions.new(perms)
 
-        context = Discord::Context(Discord::Message).new(Client, message(author_id: 1))
-        mw.call(context, ->{ true }).should be_true
+        context = Discord::Context.new(Client)
+        mw.call(message(author_id: 1), context) { true }.should be_true
       end
     end
 
@@ -62,8 +64,8 @@ describe DiscordMiddleware::Permissions do
         perms = Discord::Permissions.flags(SendMessages, ReadMessages, CreateInstantInvite)
         mw = DiscordMiddleware::Permissions.new(perms)
 
-        context = Discord::Context(Discord::Message).new(Client, message(author_id: 1))
-        mw.call(context, ->{ true }).should be_falsey
+        context = Discord::Context.new(Client)
+        mw.call(message(author_id: 1), context) { true }.should be_falsey
       end
     end
   end

--- a/spec/middleware/permissions_spec.cr
+++ b/spec/middleware/permissions_spec.cr
@@ -54,7 +54,8 @@ describe DiscordMiddleware::Permissions do
         perms = Discord::Permissions.flags(ReadMessages, CreateInstantInvite)
         mw = DiscordMiddleware::Permissions.new(perms)
 
-        context = Discord::Context.new(Client)
+        context = Discord::Context.new
+        context.put(Client)
         mw.call(message(author_id: 1), context) { true }.should be_true
       end
     end
@@ -64,7 +65,8 @@ describe DiscordMiddleware::Permissions do
         perms = Discord::Permissions.flags(SendMessages, ReadMessages, CreateInstantInvite)
         mw = DiscordMiddleware::Permissions.new(perms)
 
-        context = Discord::Context.new(Client)
+        context = Discord::Context.new
+        context.put(Client)
         mw.call(message(author_id: 1), context) { true }.should be_falsey
       end
     end

--- a/spec/middleware/prefix_spec.cr
+++ b/spec/middleware/prefix_spec.cr
@@ -7,7 +7,7 @@ describe DiscordMiddleware::Prefix do
   context "with a matching string" do
     it "passes" do
       msg = message("!ping")
-      context = Discord::Context.new(Client)
+      context = Discord::Context.new
       mw.call(msg, context) { true }.should be_true
     end
   end
@@ -15,7 +15,7 @@ describe DiscordMiddleware::Prefix do
   context "with a mismatching string" do
     it "doesn't pass" do
       msg = message("!pong")
-      context = Discord::Context.new(Client)
+      context = Discord::Context.new
       mw.call(msg, context) { true }.should be_falsey
     end
   end

--- a/spec/middleware/prefix_spec.cr
+++ b/spec/middleware/prefix_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+require "../../src/discordcr-middleware/middleware/prefix"
 
 describe DiscordMiddleware::Prefix do
   mw = DiscordMiddleware::Prefix.new("!ping")
@@ -6,18 +7,16 @@ describe DiscordMiddleware::Prefix do
   context "with a matching string" do
     it "passes" do
       msg = message("!ping")
-      context = Discord::Context(Discord::Message).new(Client, msg)
-
-      mw.call(context, ->{ true }).should be_true
+      context = Discord::Context.new(Client)
+      mw.call(msg, context) { true }.should be_true
     end
   end
 
   context "with a mismatching string" do
     it "doesn't pass" do
       msg = message("!pong")
-      context = Discord::Context(Discord::Message).new(Client, msg)
-
-      mw.call(context, ->{ true }).should be_falsey
+      context = Discord::Context.new(Client)
+      mw.call(msg, context) { true }.should be_falsey
     end
   end
 end

--- a/spec/middleware/rate_limiter_spec.cr
+++ b/spec/middleware/rate_limiter_spec.cr
@@ -13,7 +13,8 @@ describe DiscordMiddleware::RateLimiter do
           limiter,
           :foo
         )
-        ctx = Discord::Context.new(Client)
+        ctx = Discord::Context.new
+        ctx.put(Client)
 
         mw.call(message, ctx) { true }.should be_true
       end
@@ -25,7 +26,8 @@ describe DiscordMiddleware::RateLimiter do
           limiter,
           :foo
         )
-        ctx = Discord::Context.new(Client)
+        ctx = Discord::Context.new
+        ctx.put(Client)
 
         mw.call(message, ctx) { true }
         mw.call(message, ctx) { true }.should be_falsey
@@ -37,7 +39,8 @@ describe DiscordMiddleware::RateLimiter do
             limiter,
             :foo
           )
-          ctx = Discord::Context.new(Client)
+          ctx = Discord::Context.new
+          ctx.put(Client)
           msg_a = message(author_id: 0)
           msg_b = message(author_id: 1)
 

--- a/spec/middleware/time_spec.cr
+++ b/spec/middleware/time_spec.cr
@@ -15,7 +15,7 @@ describe DiscordMiddleware::Time do
     it "calls the next middleware right away" do
       mw = DiscordMiddleware::Time.new(5.milliseconds) { |ctx| true }
       msg = message
-      context = Discord::Context.new(Client)
+      context = Discord::Context.new
 
       mw.call(msg, context) { true }.should be_true
     end
@@ -24,7 +24,7 @@ describe DiscordMiddleware::Time do
       called = false
       mw = DiscordMiddleware::Time.new(5.milliseconds) { |ctx| called = true }
       msg = message
-      context = Discord::Context.new(Client)
+      context = Discord::Context.new
 
       mw.call(msg, context) { true }
       called.should be_false

--- a/spec/middleware/time_spec.cr
+++ b/spec/middleware/time_spec.cr
@@ -1,9 +1,10 @@
 require "../spec_helper"
+require "../../src/discordcr-middleware/middleware/time"
 
 describe DiscordMiddleware::Time do
   describe "#initialize" do
     it "accepts a time span with a block" do
-      block = ->(ctx : Discord::Context(Discord::Message)) {}
+      block = ->(payload : Discord::Message, ctx : Discord::Context) {}
       mw = DiscordMiddleware::Time.new(5.seconds, &block)
       mw.@delay.should eq 5.seconds
       mw.@block.should eq block
@@ -14,18 +15,18 @@ describe DiscordMiddleware::Time do
     it "calls the next middleware right away" do
       mw = DiscordMiddleware::Time.new(5.milliseconds) { |ctx| true }
       msg = message
-      context = Discord::Context(Discord::Message).new(Client, msg)
+      context = Discord::Context.new(Client)
 
-      mw.call(context, ->{ true }).should be_true
+      mw.call(msg, context) { true }.should be_true
     end
 
     it "calls the block after the time has elapsed" do
       called = false
       mw = DiscordMiddleware::Time.new(5.milliseconds) { |ctx| called = true }
       msg = message
-      context = Discord::Context(Discord::Message).new(Client, msg)
+      context = Discord::Context.new(Client)
 
-      mw.call(context, ->{ true })
+      mw.call(msg, context) { true }
       called.should be_false
 
       sleep 6.milliseconds

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,6 +1,5 @@
 require "spec"
 require "../src/discordcr-middleware"
-require "../src/discordcr-middleware/middleware/*"
 
 Client = Discord::Client.new("Bot TOKEN")
 Cache  = Discord::Cache.new(Client)
@@ -32,26 +31,28 @@ def message(content = "", author_id = 0)
 end
 
 # Middleware that tracks if it was called, and how many times
-class FlagMiddleware < Discord::Middleware
+class FlagMiddleware
+  include Discord::Middleware
   getter called = false
 
   getter counter = 0
 
   getter message : Discord::Message?
 
-  def call(context : Discord::Context(Discord::Message), done)
+  def call(payload : Discord::Message, context)
     @called = true
     @counter += 1
-    @message = context.payload
-    done.call
+    @message = payload
+    yield
   end
 end
 
 # Middleware that will not call the next middleware
-class StopMiddleware < Discord::Middleware
+class StopMiddleware
+  include Discord::Middleware
   getter called = false
 
-  def call(context : Discord::Context(Discord::Message), done)
+  def call(payload : Discord::Message, context, &block)
     @called = true
   end
 end

--- a/spec/stack_spec.cr
+++ b/spec/stack_spec.cr
@@ -27,7 +27,7 @@ describe Discord::Stack do
     it "calls each middleware" do
       middlewares = {TestMiddleware.new, TestMiddleware.new}
       stack = Discord::Stack.new(*middlewares)
-      stack.run(1, Discord::Context.new(Client))
+      stack.run(1, Discord::Context.new)
 
       middlewares.each do |mw|
         mw.called.should be_true
@@ -37,7 +37,7 @@ describe Discord::Stack do
     it "runs middleware handles multiple kinds of events" do
       middleware = TestMiddleware.new
       stack = Discord::Stack.new(middleware)
-      context = Discord::Context.new(Client)
+      context = Discord::Context.new
 
       stack.run(1, context)
       middleware.called.should be_true
@@ -51,7 +51,7 @@ describe Discord::Stack do
       it "doesn't continue" do
         middlewares = {FlagMiddleware.new, StopMiddleware.new, FlagMiddleware.new}
         stack = Discord::Stack.new(*middlewares)
-        context = Discord::Context.new(Client)
+        context = Discord::Context.new
 
         stack.run(message, context)
         (middlewares[0].called && middlewares[1].called).should be_true
@@ -61,7 +61,7 @@ describe Discord::Stack do
 
     it "accepts a block" do
       stack = Discord::Stack.new(TestMiddleware.new, TestMiddleware.new)
-      context = Discord::Context.new(Client)
+      context = Discord::Context.new
 
       ran = false
       stack.run(1, context) do |ctx|

--- a/src/discordcr-middleware.cr
+++ b/src/discordcr-middleware.cr
@@ -6,11 +6,11 @@ module Discord
     macro stack_event(event_name, klass)
       # Creates a `Client#on_{{event_name}}` handler with a middleware chain and
       # trailing block. Handles a `{{klass}}` payload.
-      def on_{{event_name}}(*middleware, &block : Context({{klass}}) ->)
+      def on_{{event_name}}(*middleware, &block : {{klass}}, Context ->)
         stack = Stack.new(*middleware)
         on_{{event_name}} do |payload|
-          context = Discord::Context({{klass}}).new(self, payload)
-          stack.run(context, 0, &block)
+          context = Discord::Context.new(self)
+          stack.run(payload, context, 0, &block)
         end
       end
 
@@ -19,8 +19,8 @@ module Discord
       def on_{{event_name}}(*middleware)
         stack = Stack.new(*middleware)
         on_{{event_name}} do |payload|
-          context = Discord::Context({{klass}}).new(self, payload)
-          stack.run(context)
+          context = Discord::Context.new(self)
+          stack.run(payload, context)
         end
       end
     end

--- a/src/discordcr-middleware.cr
+++ b/src/discordcr-middleware.cr
@@ -9,20 +9,24 @@ module Discord
       def on_{{event_name}}(*middleware, &block : {{klass}}, Context ->)
         stack = Stack.new(*middleware)
         on_{{event_name}} do |payload|
-          context = Discord::Context.new(self)
+          context = Discord::Context.new
+          context.put(self)
+          middleware.each { |mw| context.put mw }
           stack.run(payload, context, 0, &block)
-        end
-      end
+       end
+     end
 
       # Creates a `Client#on_{{event_name}}` handler with a middleware chain.
       # Handles a `{{klass}}` payload.
       def on_{{event_name}}(*middleware)
         stack = Stack.new(*middleware)
         on_{{event_name}} do |payload|
-          context = Discord::Context.new(self)
+          context = Discord::Context.new
+          context.put(self)
+          middleware.each { |mw| context.put mw }
           stack.run(payload, context)
-        end
-      end
+       end
+     end
     end
 
     stack_event dispatch, {String, IO::Memory}

--- a/src/discordcr-middleware/context.cr
+++ b/src/discordcr-middleware/context.cr
@@ -1,31 +1,18 @@
 module Discord
-  # A container for shared state throughout processing of a message
+  # A container for shared state throughout processing of an event
   class Context
-    getter client : Client
+    @extensions = Hash(Int32, Void*).new
 
-    getter state = {} of String => Nil | String | Int32 | Int64 | Float64 | Bool
-
-    property int : Int16 | Int32 | Int64 | Nil
-    property uint : UInt16 | UInt32 | UInt64 | Nil
-    property string : String?
-    property float : Float32 | Float64 | Nil
-    property bool : Bool?
-
-    def initialize(@client : Client)
+    # Access a stored value by class
+    def [](clazz : T.class) : T forall T
+      @extensions[clazz.crystal_type_id].unsafe_as(T)
     end
-  end
 
-  # Adds a `property` to `Context`
-  macro add_ctx_property(name, type)
-    class ::Discord::Context
-      property {{name}} : {{type}}
-    end
-  end
-
-  # Adds a `property!` to `Context`
-  macro add_ctx_property!(name, type)
-    class ::Discord::Context
-      property! {{name}} : {{type}}
+    # Store an object in this class. The object must be a `class`.
+    def put(extension : T) forall T
+      {% raise "Extension must be a class" unless T < Reference %}
+      raise "BUG: Reference isn't sizeof(Void*)!" unless sizeof(typeof(extension)) == sizeof(Void*)
+      @extensions[extension.class.crystal_type_id] = extension.unsafe_as(Pointer(Void))
     end
   end
 end

--- a/src/discordcr-middleware/context.cr
+++ b/src/discordcr-middleware/context.cr
@@ -1,9 +1,7 @@
 module Discord
   # A container for shared state throughout processing of a message
-  class Context(P)
+  class Context
     getter client : Client
-
-    getter payload : P
 
     getter state = {} of String => Nil | String | Int32 | Int64 | Float64 | Bool
 
@@ -13,7 +11,7 @@ module Discord
     property float : Float32 | Float64 | Nil
     property bool : Bool?
 
-    def initialize(@client : Client, @payload : P)
+    def initialize(@client : Client)
     end
   end
 

--- a/src/discordcr-middleware/middleware/author.cr
+++ b/src/discordcr-middleware/middleware/author.cr
@@ -1,17 +1,16 @@
 # Matches the author the message event was raised with based
 # on several different attributes.
-class DiscordMiddleware::Author < Discord::Middleware
+class DiscordMiddleware::Author
+  include Discord::Middleware
   include AttributeMiddleware
 
   def initialize(@id : UInt64? = nil, @username : String? = nil,
                  @discriminator : String? = nil, @bot : Bool? = nil)
   end
 
-  def call(context : Discord::Context(Discord::Message), done)
-    author = context.payload.author
-
+  def call(payload : Discord::Message, context : Discord::Context)
+    author = payload.author
     check_attributes(author)
-
-    done.call
+    yield
   end
 end

--- a/src/discordcr-middleware/middleware/cached_event.cr
+++ b/src/discordcr-middleware/middleware/cached_event.cr
@@ -22,19 +22,20 @@ module DiscordMiddleware
   # end
   # ```
   # If the cache is enabled on the client (recommended) it will be used.
-  class CachedEvent < Discord::Middleware
+  class CachedEvent
+    include Discord::Middleware
     include DiscordMiddleware::CachedRoutes
 
-    def call(context : Discord::Context(Discord::Message), done)
-      context.channel = channel = get_channel(context.client, context.payload.channel_id)
+    def call(payload : Discord::Message, context : Discord::Context)
+      context.channel = channel = get_channel(context.client, payload.channel_id)
 
       if guild_id = channel.guild_id
         context.guild = guild = get_guild(context.client, guild_id)
-        context.member = member = get_member(context.client, guild_id, context.payload.author.id)
+        context.member = member = get_member(context.client, guild_id, payload.author.id)
         context.member_roles = guild.roles.select { |r| member.roles.includes?(r.id) }
       end
 
-      done.call
+      yield
     end
   end
 end

--- a/src/discordcr-middleware/middleware/channel.cr
+++ b/src/discordcr-middleware/middleware/channel.cr
@@ -1,7 +1,8 @@
 # Matches the channel the message event was raised from based on
 # several different attributes. If the client has a cache enabled,
 # it will be used to resolve the channel the message came from.
-class DiscordMiddleware::Channel < Discord::Middleware
+class DiscordMiddleware::Channel
+  include Discord::Middleware
   include AttributeMiddleware
   include CachedRoutes
 
@@ -10,11 +11,9 @@ class DiscordMiddleware::Channel < Discord::Middleware
                  @guild_id : UInt64? = nil, @type : UInt8? = nil)
   end
 
-  def call(context : Discord::Context(Discord::Message), done)
-    ch = get_channel(context.client, context.payload.channel_id)
-
+  def call(payload : Discord::Message, context : Discord::Context)
+    ch = get_channel(context.client, payload.channel_id)
     check_attributes(ch)
-
-    done.call
+    yield
   end
 end

--- a/src/discordcr-middleware/middleware/channel.cr
+++ b/src/discordcr-middleware/middleware/channel.cr
@@ -12,7 +12,8 @@ class DiscordMiddleware::Channel
   end
 
   def call(payload : Discord::Message, context : Discord::Context)
-    ch = get_channel(context.client, payload.channel_id)
+    client = context[Discord::Client]
+    ch = get_channel(client, payload.channel_id)
     check_attributes(ch)
     yield
   end

--- a/src/discordcr-middleware/middleware/conditional.cr
+++ b/src/discordcr-middleware/middleware/conditional.cr
@@ -2,10 +2,10 @@
 # conditions from the context or elsewhere, but don't want to write
 # your own middleware to do it.
 class DiscordMiddleware::Conditional
-  def initialize(@condition : Proc(Discord::Context(Discord::Message), Bool))
+  def initialize(@condition : Proc(Discord::Message, Discord::Context, Bool))
   end
 
-  def call(context : Discord::Context(Discord::Message), done)
-    done.call if @condition.call(context)
+  def call(payload : Discord::Message, context : Discord::Context)
+    yield if @condition.call(payload, context)
   end
 end

--- a/src/discordcr-middleware/middleware/error.cr
+++ b/src/discordcr-middleware/middleware/error.cr
@@ -27,7 +27,7 @@ class DiscordMiddleware::Error
     if message = @message
       channel_id = payload.channel_id
       message = message.gsub("%exception%", ex.message)
-      context.client.create_message(channel_id, message)
+      context[Discord::Client].create_message(channel_id, message)
     end
 
     @block.try &.call(payload, context)

--- a/src/discordcr-middleware/middleware/permissions.cr
+++ b/src/discordcr-middleware/middleware/permissions.cr
@@ -94,16 +94,17 @@ class DiscordMiddleware::Permissions
   end
 
   def call(payload : Discord::Message, context : Discord::Context)
-    channel = get_channel(context.client, payload.channel_id)
+    client = context[Discord::Client]
+    channel = get_channel(client, payload.channel_id)
     user_id = payload.author.id
 
     if guild_id = channel.guild_id
-      guild = get_guild(context.client, guild_id)
+      guild = get_guild(client, guild_id)
 
       # Pass if the user is the owner of the guild
       yield if guild.owner_id == user_id
 
-      member = get_member(context.client, guild_id, user_id)
+      member = get_member(client, guild_id, user_id)
       permissions = base_permissions_for(member, in: guild)
 
       # Pass if user has an administrator role

--- a/src/discordcr-middleware/middleware/prefix.cr
+++ b/src/discordcr-middleware/middleware/prefix.cr
@@ -6,11 +6,13 @@
 #   client.create_message(channel_id, "pong")
 # end
 # ```
-class DiscordMiddleware::Prefix < Discord::Middleware
+class DiscordMiddleware::Prefix
+  include Discord::Middleware
+
   def initialize(@prefix : String | Char)
   end
 
-  def call(context : Discord::Context(Discord::Message), done)
-    done.call if context.payload.content.starts_with?(@prefix)
+  def call(payload : Discord::Message, context : Discord::Context)
+    yield if payload.content.starts_with?(@prefix)
   end
 end

--- a/src/discordcr-middleware/middleware/time.cr
+++ b/src/discordcr-middleware/middleware/time.cr
@@ -11,17 +11,19 @@
 #   context.client.create_message(channel_id, "Going away for 5 seconds..")
 # end
 # ```
-class DiscordMiddleware::Time < Discord::Middleware
-  def initialize(@delay : ::Time::Span, &block : Discord::Context(Discord::Message) ->)
+class DiscordMiddleware::Time
+  include Discord::Middleware
+
+  def initialize(@delay : ::Time::Span, &block : Discord::Message, Discord::Context ->)
     @block = block
   end
 
-  def call(context : Discord::Context(Discord::Message), done)
+  def call(payload : Discord::Message, context : Discord::Context)
     spawn do
       sleep @delay
-      @block.call(context)
+      @block.call(payload, context)
     end
 
-    done.call
+    yield
   end
 end


### PR DESCRIPTION
Depends on #10 

Re-implements `Context` as a hash of type ID to a reference.
- Removes `Discord.add_ctx_property` / `Discord.add_ctx_property!` macros
- Arbitrary classes can be stored in `Context` via `Context#put`
```cr
class Foo
  getter value
  def initialize(@value : Int32)
  end
end

context = Context.new
context.put(Foo.new(1))
context[Foo].value #=> 1
```
- When creating handlers, the receiving client will `#put(self)` onto the `Context` before running the stack. Access the `Client` via:
```cr
context[Discord::Client]
```
- When creating handlers, each middleware will be `#put` onto the `Context` before running the stack. This enables you to "reach back" into the middleware after they've all run:
```cr
class SplitParser
  getter arguments = [] of String

  def call(payload : Discord::Message, context)
    @arguments = payload.content.split(' ', remove_empty: true)
    yield
  end
end

client.on_message_create(SplitParser.new) do |payload, context|
  context[SplitParser].arguments #=> ["!add", "1", "2"]
end
```